### PR TITLE
Feature/29 allow cognito to use only google id provider

### DIFF
--- a/cdk/lib/nishikiBackend-stack.ts
+++ b/cdk/lib/nishikiBackend-stack.ts
@@ -80,9 +80,7 @@ export class NishikiBackendStack extends cdk.Stack {
 				userSrp: true,
 			},
 			generateSecret: false,
-			supportedIdentityProviders: [
-				UserPoolClientIdentityProvider.GOOGLE,
-			],
+			supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
 			oAuth: {
 				flows: {
 					authorizationCodeGrant: true,

--- a/cdk/lib/nishikiBackend-stack.ts
+++ b/cdk/lib/nishikiBackend-stack.ts
@@ -81,7 +81,6 @@ export class NishikiBackendStack extends cdk.Stack {
 			},
 			generateSecret: false,
 			supportedIdentityProviders: [
-				UserPoolClientIdentityProvider.COGNITO,
 				UserPoolClientIdentityProvider.GOOGLE,
 			],
 			oAuth: {


### PR DESCRIPTION
## Overviews of implementation
I just deleted CognitoID Provider in `supportedIdentityProviders` of the user pool client.

## Review points

