### PR TITLE
fix: change the restriction about the name length

### DIFF
--- a/backend/main/src/Food/Domain/Unit.ts
+++ b/backend/main/src/Food/Domain/Unit.ts
@@ -11,7 +11,7 @@ interface IUnitProps {
  */
 export class Unit extends ValueObject<IUnitProps> {
 	static create(props: IUnitProps): Result<Unit, UnitDomainError> {
-		if (props.name.length > 10) {
+		if (props.name.length > 20) {
 			return Err(new UnitDomainError("Unit name is too long"));
 		}
 		return Ok(new Unit(props));

--- a/backend/main/test/Food/Domain/Unit.test.ts
+++ b/backend/main/test/Food/Domain/Unit.test.ts
@@ -16,7 +16,7 @@ describe("Unit Object", () => {
 		});
 
 		it("unit name too long", () => {
-			const unitName = "12345678901"; // 11 character
+			const unitName = "123456789012345678901"; // 21 character
 			const unit = Unit.create({
 				name: unitName,
 			});


### PR DESCRIPTION
## Overviews of implementation
changed the restriction about the length of the unit name from 10 characters to 20.

## Review points

