### PR TITLE
make unit and quantity unnecessary

### DIFF
--- a/backend/main/src/Group/Domain/Entities/Food.ts
+++ b/backend/main/src/Group/Domain/Entities/Food.ts
@@ -90,17 +90,12 @@ export class Food extends Entity<string, IFoodProps> {
 	 * @return Food
 	 */
 	public addQuantity(quantity: Quantity): Result<Food, FoodDomainError> {
-		if (!this.props.quantity) {
-			return Food.create(this.id, {
-				...this.props,
-				quantity: quantity,
-			});
-		}
-
-		const addedQuantity = this.props.quantity.add(quantity);
+		const newQuantity = this.props.quantity
+			? this.props.quantity.add(quantity)
+			: quantity;
 		return Food.create(this.id, {
 			...this.props,
-			quantity: addedQuantity,
+			quantity: newQuantity,
 		});
 	}
 

--- a/backend/main/src/Group/Domain/Entities/Food.ts
+++ b/backend/main/src/Group/Domain/Entities/Food.ts
@@ -90,7 +90,7 @@ export class Food extends Entity<string, IFoodProps> {
 	 * @return Food
 	 */
 	public addQuantity(quantity: Quantity): Result<Food, FoodDomainError> {
-		if(!this.props.quantity) {
+		if (!this.props.quantity) {
 			return Food.create(this.id, {
 				...this.props,
 				quantity: quantity,
@@ -111,7 +111,7 @@ export class Food extends Entity<string, IFoodProps> {
 	 * @return Food
 	 */
 	public subtractQuantity(quantity: Quantity): Result<Food, FoodDomainError> {
-		if(!this.props.quantity) {
+		if (!this.props.quantity) {
 			return Err(new FoodDomainError("Food quantity is not set"));
 		}
 

--- a/backend/main/src/Group/Domain/Entities/Food.ts
+++ b/backend/main/src/Group/Domain/Entities/Food.ts
@@ -7,8 +7,8 @@ import { Err, Ok, Result } from "result-ts-type";
 
 interface IFoodProps {
 	name: string;
-	unit: Unit;
-	quantity: Quantity;
+	unit?: Unit;
+	quantity?: Quantity;
 	expiry?: Expiry;
 }
 /**
@@ -85,12 +85,19 @@ export class Food extends Entity<string, IFoodProps> {
 
 	/**
 	 * add food's quantity.
+	 * if quantity is undefined, return Food with the passed quantity.
 	 * @param quantity
 	 * @return Food
 	 */
 	public addQuantity(quantity: Quantity): Result<Food, FoodDomainError> {
-		const addedQuantity = this.props.quantity.add(quantity);
+		if(!this.props.quantity) {
+			return Food.create(this.id, {
+				...this.props,
+				quantity: quantity,
+			});
+		}
 
+		const addedQuantity = this.props.quantity.add(quantity);
 		return Food.create(this.id, {
 			...this.props,
 			quantity: addedQuantity,
@@ -99,11 +106,15 @@ export class Food extends Entity<string, IFoodProps> {
 
 	/**
 	 * subtract food's quantity.
-	 * if subtracted quantity is less than 0, return error.
+	 * if subtracted quantity is undefined or less than 0, return error.
 	 * @param quantity
 	 * @return Food
 	 */
 	public subtractQuantity(quantity: Quantity): Result<Food, FoodDomainError> {
+		if(!this.props.quantity) {
+			return Err(new FoodDomainError("Food quantity is not set"));
+		}
+
 		const subtractedQuantityOrError = this.props.quantity.subtract(quantity);
 		if (!subtractedQuantityOrError.ok) {
 			return Err(subtractedQuantityOrError.error);

--- a/backend/main/test/Group/Domain/Entities/Food.test.ts
+++ b/backend/main/test/Group/Domain/Entities/Food.test.ts
@@ -111,8 +111,9 @@ describe("Food Entity", () => {
 			const changedFoodQuantity = Quantity.create(200).unwrap();
 			const expectedFoodQuantity = Quantity.create(200).unwrap();
 
-			const changedFood =
-				foodWithRequiredProps.addQuantity(changedFoodQuantity).unwrap();
+			const changedFood = foodWithRequiredProps
+				.addQuantity(changedFoodQuantity)
+				.unwrap();
 			expect(changedFood.quantity).toMatchObject(expectedFoodQuantity);
 		});
 		it("subtract food quantity when it's undefined", () => {

--- a/backend/main/test/Group/Domain/Entities/Food.test.ts
+++ b/backend/main/test/Group/Domain/Entities/Food.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Food, FoodId } from "src/Group/Domain/Entities/Food";
+import { Food, FoodDomainError, FoodId } from "src/Group/Domain/Entities/Food";
 import {
 	Quantity,
 	QuantityError,
@@ -15,11 +15,11 @@ describe("Food Entity", () => {
 
 	const requiredFoodProps = {
 		name: "dummy food name",
-		unit: unit,
-		quantity: quantity,
 	};
 	const fullFoodProps = {
 		...requiredFoodProps,
+		unit: unit,
+		quantity: quantity,
 		expiry: expiry,
 	};
 	describe("Construct Food Object", () => {
@@ -33,8 +33,6 @@ describe("Food Entity", () => {
 			const food = Food.create(foodId, requiredFoodProps);
 			expect(food.ok).toBeTruthy();
 			expect(food.unwrap().name).toBe(fullFoodProps.name);
-			expect(food.unwrap().unit).toBe(fullFoodProps.unit);
-			expect(food.unwrap().quantity).toBe(fullFoodProps.quantity);
 			expect(food.unwrap().expiry).toBeUndefined();
 		});
 
@@ -102,8 +100,30 @@ describe("Food Entity", () => {
 
 				const changedFood =
 					foodWithRequiredProps.subtractQuantity(changedFoodQuantity);
-				expect(changedFood.unwrapError()).instanceOf(QuantityError);
+				expect(changedFood.unwrapError()).instanceOf(FoodDomainError);
 			});
+		});
+
+		it("add food quantity when it's undefined", () => {
+			const food = Food.create(foodId, {
+				name: "dummy food name",
+			}).unwrap();
+			const changedFoodQuantity = Quantity.create(200).unwrap();
+			const expectedFoodQuantity = Quantity.create(200).unwrap();
+
+			const changedFood =
+				foodWithRequiredProps.addQuantity(changedFoodQuantity).unwrap();
+			expect(changedFood.quantity).toMatchObject(expectedFoodQuantity);
+		});
+		it("subtract food quantity when it's undefined", () => {
+			const food = Food.create(foodId, {
+				name: "dummy food name",
+			}).unwrap();
+			const changedFoodQuantity = Quantity.create(1).unwrap();
+
+			const changedFood =
+				foodWithRequiredProps.subtractQuantity(changedFoodQuantity);
+			expect(changedFood.unwrapError()).instanceOf(FoodDomainError);
 		});
 
 		describe("change food expiry", () => {


### PR DESCRIPTION
## Overviews of implementation
make unit and quantity unnecessary

## Review points
Is there a better idea to write the following code in addQuantity? I feel it's kinda redundant.
```typescript
		if(!this.props.quantity) {
			return Food.create(this.id, {
				...this.props,
				quantity: quantity,
			});
		}
```
