### PR TITLE
Feature/165 add category property to food entity

### DIFF
--- a/backend/main/src/Group/Controllers/AddFoodToContainerController.ts
+++ b/backend/main/src/Group/Controllers/AddFoodToContainerController.ts
@@ -9,6 +9,7 @@ interface IAddFoodToContainerInput {
 	unit?: string;
 	quantity?: number;
 	expiry?: Date;
+	category: string;
 }
 
 export class AddFoodToContainerController extends Controller<IAddFoodToContainerInput> {

--- a/backend/main/src/Group/Controllers/UpdateFoodOfContainerController.ts
+++ b/backend/main/src/Group/Controllers/UpdateFoodOfContainerController.ts
@@ -10,6 +10,7 @@ interface IUpdateFoodOfContainerInput {
 	unit?: string;
 	quantity?: number;
 	expiry?: Date;
+	category: string;
 }
 
 export class UpdateFoodOfContainerController extends Controller<IUpdateFoodOfContainerInput> {

--- a/backend/main/src/Group/Domain/Entities/Food.ts
+++ b/backend/main/src/Group/Domain/Entities/Food.ts
@@ -11,6 +11,7 @@ export interface IFoodProps {
 	unit?: Unit;
 	quantity?: Quantity;
 	expiry?: Expiry;
+	category: string;
 }
 /**
  * This class is food class.
@@ -46,6 +47,10 @@ export class Food extends Entity<string, IFoodProps> {
 
 	get expiry(): Expiry | undefined {
 		return this.props?.expiry;
+	}
+
+	get category(): string {
+		return this.props.category;
 	}
 
 	/**

--- a/backend/main/src/Group/Dtos/FoodDto.ts
+++ b/backend/main/src/Group/Dtos/FoodDto.ts
@@ -5,6 +5,7 @@ export interface IFoodDto {
 	unit?: string;
 	quantity?: number;
 	expiry?: Date;
+	category: string;
 }
 
 export const foodDtoMapper = (food: Food): IFoodDto => {
@@ -13,5 +14,6 @@ export const foodDtoMapper = (food: Food): IFoodDto => {
 		unit: food.unit?.name,
 		quantity: food.quantity?.quantity,
 		expiry: food.expiry?.date,
+		category: food.category,
 	};
 };

--- a/backend/main/src/Group/UseCases/AddFoodToContainerUseCase/IAddFoodToContainerUseCase.ts
+++ b/backend/main/src/Group/UseCases/AddFoodToContainerUseCase/IAddFoodToContainerUseCase.ts
@@ -11,6 +11,7 @@ export interface IAddFoodToContainerUseCase {
 	unit?: string;
 	quantity?: number;
 	expiry?: Date;
+	category: string;
 }
 
 export class ContainerIsNotExisting extends UseCaseError {}

--- a/backend/main/src/Group/UseCases/UpdateFoodOfContainerUseCase/IUpdateFoodOfContainerUseCase.ts
+++ b/backend/main/src/Group/UseCases/UpdateFoodOfContainerUseCase/IUpdateFoodOfContainerUseCase.ts
@@ -12,8 +12,7 @@ export interface IUpdateFoodOfContainerUseCase {
 	unit?: string;
 	quantity?: number;
 	expiry?: Date;
-	// TODO: add category to Food entity
-	// category: string;
+	category: string;
 }
 
 export class ContainerIsNotExisting extends UseCaseError {}

--- a/backend/main/test/Group/Domain/Entities/Food.test.ts
+++ b/backend/main/test/Group/Domain/Entities/Food.test.ts
@@ -24,9 +24,11 @@ describe("Food Entity", () => {
 	const quantity = Quantity.create(1).unwrap();
 	const expiry = Expiry.create({ date: new Date(2023, 11, 1) }).unwrap();
 	const foodId = FoodId.generate();
+	const category = "dummy category";
 
 	const requiredFoodProps = {
 		name: "dummy food name",
+		category: category,
 	};
 	const fullFoodProps = {
 		...requiredFoodProps,

--- a/backend/main/test/Group/UseCase/AddFoodToContainerUseCase.test.ts
+++ b/backend/main/test/Group/UseCase/AddFoodToContainerUseCase.test.ts
@@ -27,6 +27,7 @@ describe("add a food to container use case", () => {
 	const quantity = Quantity.create(1).unwrap();
 	const expiry = Expiry.create({ date: new Date() }).unwrap();
 	const foodName = "dummy food name";
+	const category = "dummy category";
 
 	const groupId = GroupId.create("dummyGroupId").unwrap();
 	const groupName = "dummyGroupName";
@@ -35,6 +36,16 @@ describe("add a food to container use case", () => {
 		containerIds: [containerId],
 		userIds: [USER_ID],
 	}).unwrap();
+
+	const addFoodRequest = {
+		userId: USER_ID.id,
+		containerId: containerId.id,
+		name: foodName,
+		unit: unit.name,
+		quantity: quantity.quantity,
+		expiry: expiry.date,
+		category: category,
+	};
 
 	beforeEach(() => {
 		mockContainerRepository = new MockContainerRepository();
@@ -57,26 +68,12 @@ describe("add a food to container use case", () => {
 			Promise.resolve(container),
 		);
 
-		const result = await useCase.execute({
-			userId: USER_ID.id,
-			containerId: containerId.id,
-			name: foodName,
-			unit: unit.name,
-			quantity: quantity.quantity,
-			expiry: expiry.date,
-		});
+		const result = await useCase.execute(addFoodRequest);
 		expect(result.ok).toBeTruthy();
 	});
 
 	it("Container not found", async () => {
-		const result = await useCase.execute({
-			userId: USER_ID.id,
-			containerId: containerId.id,
-			name: foodName,
-			unit: unit.name,
-			quantity: quantity.quantity,
-			expiry: expiry.date,
-		});
+		const result = await useCase.execute(addFoodRequest);
 		expect(result.ok).toBeFalsy();
 		expect(result.unwrapError()).instanceOf(ContainerIsNotExisting);
 	});
@@ -88,14 +85,7 @@ describe("add a food to container use case", () => {
 		vi.spyOn(mockGroupRepository, "find").mockReturnValueOnce(
 			Promise.resolve(null),
 		);
-		const result = await useCase.execute({
-			userId: USER_ID.id,
-			containerId: containerId.id,
-			name: foodName,
-			unit: unit.name,
-			quantity: quantity.quantity,
-			expiry: expiry.date,
-		});
+		const result = await useCase.execute(addFoodRequest);
 		expect(result.ok).toBeFalsy();
 		expect(result.unwrapError()).toBeInstanceOf(ContainerIsNotExisting);
 	});
@@ -110,12 +100,8 @@ describe("add a food to container use case", () => {
 		);
 
 		const result = await useCase.execute({
+			...addFoodRequest,
 			userId: anotherUserId,
-			containerId: containerId.id,
-			name: foodName,
-			unit: unit.name,
-			quantity: quantity.quantity,
-			expiry: expiry.date,
 		});
 		expect(result.ok).toBeFalsy();
 		expect(result.unwrapError()).instanceOf(UserIsNotAuthorized);


### PR DESCRIPTION
## Overviews of implementation
add category to Food entity

## Review points
I didn't implement the changeCategory method in the Food entity because it won't be used in 1st release.
What do you think I added category as a string prop instead of ValueObject? I think it's okay that the backend system just accepts received category strings and then saves them to DB.
