### PR TITLE
Feature/199 add deleteuserfromgroup usecase

### DIFF
--- a/backend/main/src/Group/Controllers/DeleteUserFromGroupController.ts
+++ b/backend/main/src/Group/Controllers/DeleteUserFromGroupController.ts
@@ -1,0 +1,30 @@
+import { Controller } from "src/Shared";
+import { DeleteUserFromGroupUseCase } from "src/Group/UseCases/DeleteUserFromGroupUseCase/DeleteUserFromGroupUseCase";
+import { UserIsNotAuthorized } from "src/Group/UseCases/DeleteUserFromGroupUseCase/IDeleteUserFromGroupUseCase";
+
+interface IDeleteUserFromGroupInput {
+	userId: string;
+	groupId: string;
+	targetUserId: string;
+}
+
+export class DeleteUserFromGroupController extends Controller<IDeleteUserFromGroupInput> {
+	readonly useCase: DeleteUserFromGroupUseCase;
+
+	constructor(useCase: DeleteUserFromGroupUseCase) {
+		super();
+		this.useCase = useCase;
+	}
+	protected async handler(input: IDeleteUserFromGroupInput) {
+		const result = await this.useCase.execute({ ...input });
+
+		if (!result.ok) {
+			if (result.error instanceof UserIsNotAuthorized) {
+				return this.forbidden(result.error.message);
+			}
+			return this.badRequest(result.error.message);
+		}
+
+		return this.noContent();
+	}
+}

--- a/backend/main/src/Group/Domain/Entities/Group.ts
+++ b/backend/main/src/Group/Domain/Entities/Group.ts
@@ -150,14 +150,16 @@ export class Group extends AggregateRoot<string, IGroupProps> {
 	 * @param userId
 	 */
 	public removeUserId(userId: UserId): Result<Group, GroupDomainError> {
-		const userIds = this.props.userIds.filter((uid) => uid.equal(userId));
-		if (userIds.length === this.props.userIds.length) {
+		const unmatchedUserIds = this.props.userIds.filter(
+			(uid) => !uid.equal(userId),
+		);
+		if (unmatchedUserIds.length === this.props.userIds.length) {
 			return Err(new GroupDomainError("The userId doesn't exist in the group"));
 		}
 
 		return Group.create(this.id, {
 			...this.props,
-			userIds: userIds,
+			userIds: unmatchedUserIds,
 		});
 	}
 }

--- a/backend/main/src/Group/UseCases/DeleteUserFromGroupUseCase/DeleteUserFromGroupUseCase.ts
+++ b/backend/main/src/Group/UseCases/DeleteUserFromGroupUseCase/DeleteUserFromGroupUseCase.ts
@@ -1,0 +1,80 @@
+import { IGroupRepository } from "src/Group/Domain/IGroupRepository";
+import { GroupId } from "src/Group/Domain/Entities/Group";
+import { IUseCase } from "src/Shared";
+import { Err, Ok, Result } from "result-ts-type";
+import {
+	DeleteUserFromGroupUseCaseErrorType,
+	IDeleteUserFromGroupUseCase,
+	GroupIsNotExisting,
+	UserIsNotAuthorized,
+} from "src/Group/UseCases/DeleteUserFromGroupUseCase/IDeleteUserFromGroupUseCase";
+import { UserId } from "src/User";
+
+/**
+ * delete a User from a group.
+ */
+export class DeleteUserFromGroupUseCase
+	implements
+		IUseCase<
+			IDeleteUserFromGroupUseCase,
+			undefined,
+			DeleteUserFromGroupUseCaseErrorType
+		>
+{
+	private readonly groupRepository: IGroupRepository;
+
+	constructor(groupRepository: IGroupRepository) {
+		this.groupRepository = groupRepository;
+	}
+
+	public async execute(
+		request: IDeleteUserFromGroupUseCase,
+	): Promise<Result<undefined, DeleteUserFromGroupUseCaseErrorType>> {
+		const { userId, groupId, targetUserId } = request;
+
+		const groupIdOrError = GroupId.create(groupId);
+		if (!groupIdOrError.ok) {
+			return Err(groupIdOrError.error);
+		}
+		const groupIdValue = groupIdOrError.value;
+
+		const group = await this.groupRepository.find(groupIdValue);
+		if (!group) {
+			return Err(
+				new GroupIsNotExisting("The requested group is not existing."),
+			);
+		}
+
+		// check the user is the member of the group
+		const userIdOrError = UserId.create(userId);
+		if (!userIdOrError.ok) {
+			return Err(userIdOrError.error);
+		}
+		const userIdValue = userIdOrError.value;
+		const canEdit = group.canEdit(userIdValue);
+
+		if (!canEdit) {
+			return Err(
+				new UserIsNotAuthorized(
+					"The user is not authorized to access the group.",
+				),
+			);
+		}
+
+		const targetUserIdOrError = UserId.create(targetUserId);
+		if (!targetUserIdOrError.ok) {
+			return Err(targetUserIdOrError.error);
+		}
+		const targetUserIdValue = targetUserIdOrError.value;
+
+		const newGroupOrError = group.removeUserId(targetUserIdValue);
+		if (!newGroupOrError.ok) {
+			return Err(newGroupOrError.error);
+		}
+		const newGroup = newGroupOrError.value;
+
+		await this.groupRepository.update(newGroup);
+
+		return Ok(undefined);
+	}
+}

--- a/backend/main/src/Group/UseCases/DeleteUserFromGroupUseCase/IDeleteUserFromGroupUseCase.ts
+++ b/backend/main/src/Group/UseCases/DeleteUserFromGroupUseCase/IDeleteUserFromGroupUseCase.ts
@@ -1,0 +1,20 @@
+import { UseCaseError } from "src/Shared";
+import {
+	GroupIdDomainError,
+	GroupDomainError,
+} from "src/Group/Domain/Entities/Group";
+
+export interface IDeleteUserFromGroupUseCase {
+	userId: string;
+	groupId: string;
+	targetUserId: string;
+}
+
+export class GroupIsNotExisting extends UseCaseError {}
+export class UserIsNotAuthorized extends UseCaseError {}
+
+export type DeleteUserFromGroupUseCaseErrorType =
+	| GroupIsNotExisting
+	| GroupIdDomainError
+	| GroupDomainError
+	| UserIsNotAuthorized;

--- a/backend/main/test/Group/UseCase/DeleteUserFromGroupUseCase.test.ts
+++ b/backend/main/test/Group/UseCase/DeleteUserFromGroupUseCase.test.ts
@@ -80,8 +80,10 @@ describe("delete a user from group use case", () => {
 			...deleteUserProp,
 			userId: anotherUserId,
 		});
+
+		const groupInRepository = await mockGroupRepository.find(groupId);
 		expect(result.ok).toBeFalsy();
 		expect(result.unwrapError()).instanceOf(UserIsNotAuthorized);
-		await expect(mockGroupRepository.find(groupId)).resolves.toBe(group);
+		expect(groupInRepository?.userIds[0].id).toBe(USER_ID.id);
 	});
 });

--- a/backend/main/test/Group/UseCase/DeleteUserFromGroupUseCase.test.ts
+++ b/backend/main/test/Group/UseCase/DeleteUserFromGroupUseCase.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteUserFromGroupUseCase } from "src/Group/UseCases/DeleteUserFromGroupUseCase/DeleteUserFromGroupUseCase";
+import { MockGroupRepository } from "../MockGroupRepository";
+import {
+	Group,
+	GroupDomainError,
+	GroupId,
+} from "src/Group/Domain/Entities/Group";
+import {
+	GroupIsNotExisting,
+	UserIsNotAuthorized,
+} from "src/Group/UseCases/DeleteUserFromGroupUseCase/IDeleteUserFromGroupUseCase";
+import { UserId } from "src/User";
+
+const USER_ID = UserId.generate();
+
+describe("delete a user from group use case", () => {
+	let mockGroupRepository: MockGroupRepository;
+	let useCase: DeleteUserFromGroupUseCase;
+
+	const targetUserId = UserId.generate();
+
+	const groupId = GroupId.generate();
+	const groupName = "dummyGroupName";
+	const group = Group.create(groupId, {
+		name: groupName,
+		containerIds: [],
+		userIds: [USER_ID, targetUserId],
+	}).unwrap();
+
+	const deleteUserProp = {
+		userId: USER_ID.id,
+		groupId: groupId.id,
+		targetUserId: targetUserId.id,
+	};
+
+	beforeEach(() => {
+		mockGroupRepository = new MockGroupRepository();
+		useCase = new DeleteUserFromGroupUseCase(mockGroupRepository);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("delete a user from a exiting group", async () => {
+		mockGroupRepository.pushDummyData(group);
+
+		const result = await useCase.execute({
+			...deleteUserProp,
+		});
+		expect(result.ok).toBeTruthy();
+	});
+
+	it("Group not found", async () => {
+		const result = await useCase.execute({
+			...deleteUserProp,
+		});
+		expect(result.ok).toBeFalsy();
+		expect(result.unwrapError()).instanceOf(GroupIsNotExisting);
+	});
+
+	it("User not found", async () => {
+		const anotherUserId = UserId.generate().id;
+
+		mockGroupRepository.pushDummyData(group);
+		const result = await useCase.execute({
+			...deleteUserProp,
+			targetUserId: anotherUserId,
+		});
+		expect(result.ok).toBeFalsy();
+		expect(result.unwrapError()).instanceOf(GroupDomainError);
+	});
+	it("User is not authorized", async () => {
+		const anotherUserId = UserId.generate().id;
+
+		mockGroupRepository.pushDummyData(group);
+
+		const result = await useCase.execute({
+			...deleteUserProp,
+			userId: anotherUserId,
+		});
+		expect(result.ok).toBeFalsy();
+		expect(result.unwrapError()).instanceOf(UserIsNotAuthorized);
+		await expect(mockGroupRepository.find(groupId)).resolves.toBe(group);
+	});
+});


### PR DESCRIPTION
## Overviews of implementation
add delete user from group usecase
add delete user from group controller
fix removeUserId method of Group Entity

## Review points
check if the test case is appropriate
I didn't change the removeUserId method's name to removeUser because it doesn't remove a user object unlike removeFood method of the Container entity. Is it fine?