### PR TITLE
Fix/291 cannot find list of containers belonging to a group

### DIFF
--- a/backend/main/src/Group/UseCases/CreateContainerUseCase/CreateContainerUseCase.ts
+++ b/backend/main/src/Group/UseCases/CreateContainerUseCase/CreateContainerUseCase.ts
@@ -75,7 +75,15 @@ export class CreateContainerUseCase
 
 		const container = containerOrError.value;
 
+		const newGroupOrError = group.addContainerId(containerId);
+		if (!newGroupOrError.ok) {
+			return Err(newGroupOrError.error);
+		}
+		const newGroup = newGroupOrError.value;
+
 		await this.containerRepository.create(container);
+		// add containerId to the Group
+		await this.groupRepository.create(newGroup);
 
 		return Ok(containerDtoMapper(container));
 	}

--- a/backend/main/src/Group/UseCases/CreateContainerUseCase/CreateContainerUseCase.ts
+++ b/backend/main/src/Group/UseCases/CreateContainerUseCase/CreateContainerUseCase.ts
@@ -81,9 +81,11 @@ export class CreateContainerUseCase
 		}
 		const newGroup = newGroupOrError.value;
 
-		await this.containerRepository.create(container);
-		// add containerId to the Group
-		await this.groupRepository.create(newGroup);
+		await Promise.all([
+			this.containerRepository.create(container),
+			// add containerId to the Group
+			this.groupRepository.update(newGroup),
+		]);
 
 		return Ok(containerDtoMapper(container));
 	}

--- a/backend/main/test/Group/MockGroupRepository.ts
+++ b/backend/main/test/Group/MockGroupRepository.ts
@@ -20,7 +20,13 @@ export class MockGroupRepository implements IGroupRepository {
 		);
 	}
 	async create(group: Group): Promise<undefined> {
-		this.memoryGroups.push(group);
+		if (this.memoryGroups.find((el) => el.id.equal(group.id))) {
+			this.memoryGroups = this.memoryGroups.map((el) =>
+				el.id.equal(group.id) ? group : el,
+			);
+		} else {
+			this.memoryGroups.push(group);
+		}
 	}
 	async update(group: Group): Promise<undefined> {
 		if (this.memoryGroups.find((el) => el.id.equal(group.id))) {

--- a/backend/main/test/Group/UseCase/CreateContainerUseCase.test.ts
+++ b/backend/main/test/Group/UseCase/CreateContainerUseCase.test.ts
@@ -42,15 +42,17 @@ describe("create container use case", () => {
 			// @ts-ignore
 			Promise.resolve(null),
 		);
-		vi.spyOn(mockGroupRepository, "find").mockReturnValueOnce(
-			Promise.resolve(group),
-		);
+		mockGroupRepository.pushDummyData(group);
 
 		const result = await useCase.execute({
 			groupId: groupId.id,
 			userId: USER_ID.id,
 		});
+		const newGroup = await mockGroupRepository.find(group.id);
+
 		expect(result.ok).toBeTruthy();
+		// group should be updated as well
+		expect(newGroup?.containerIds.length).toBe(1);
 	});
 	it("create container with name", async () => {
 		// when the container is not registered yet.


### PR DESCRIPTION
## Overviews of implementation
When a container is created, the group is updated to include the container ID.
I should have updated the Group following the creation of a container.

## Review points

