### PR TITLE
Feat/296 allow access from cross origin in lambda and api gateway

### DIFF
--- a/backend/main/src/handler.ts
+++ b/backend/main/src/handler.ts
@@ -8,7 +8,7 @@ import { cors } from "hono/cors";
 const app = new Hono();
 
 app.use("*", logger());
-app.use("*", cors({ origin: ["http://localhost:3000"] }));
+app.use("*", cors({ origin: ["http://localhost:3000","https://nishiki.tech"] }));
 
 userRouter(app); // /users
 authRouter(app); // /auth

--- a/backend/main/src/handler.ts
+++ b/backend/main/src/handler.ts
@@ -8,7 +8,10 @@ import { cors } from "hono/cors";
 const app = new Hono();
 
 app.use("*", logger());
-app.use("*", cors({ origin: ["http://localhost:3000","https://nishiki.tech"] }));
+app.use(
+	"*",
+	cors({ origin: ["http://localhost:3000", "https://nishiki.tech"] }),
+);
 
 userRouter(app); // /users
 authRouter(app); // /auth

--- a/backend/main/src/handler.ts
+++ b/backend/main/src/handler.ts
@@ -3,10 +3,12 @@ import { handle } from "hono/aws-lambda";
 import { authRouter, userRouter } from "src/User";
 import { containerRouter, groupRouter } from "src/Group";
 import { logger } from "hono/logger";
+import { cors } from "hono/cors";
 
 const app = new Hono();
 
 app.use("*", logger());
+app.use("*", cors({ origin: ["http://localhost:3000"] }));
 
 userRouter(app); // /users
 authRouter(app); // /auth

--- a/cdk/lib/nishikiBackend-stack.ts
+++ b/cdk/lib/nishikiBackend-stack.ts
@@ -52,7 +52,7 @@ export class NishikiBackendStack extends cdk.Stack {
 			handler: mainFunction,
 			proxy: true,
 			defaultCorsPreflightOptions: {
-				allowOrigins: ["http://localhost:3000"],
+				allowOrigins: ["http://localhost:3000", "https://nishiki.tech"],
 			},
 			defaultMethodOptions: {
 				authorizer: nishikiBackendAPIAuthorizer(this, userPool),

--- a/cdk/lib/nishikiBackend-stack.ts
+++ b/cdk/lib/nishikiBackend-stack.ts
@@ -51,6 +51,9 @@ export class NishikiBackendStack extends cdk.Stack {
 			restApiName: `nishiki-endpoint-${stage}-api-gateway`,
 			handler: mainFunction,
 			proxy: true,
+			defaultCorsPreflightOptions: {
+				allowOrigins: ["http://localhost:3000"],
+			},
 			defaultMethodOptions: {
 				authorizer: nishikiBackendAPIAuthorizer(this, userPool),
 			},

--- a/cdk/lib/nishikiStaticAssets-stack.ts
+++ b/cdk/lib/nishikiStaticAssets-stack.ts
@@ -156,6 +156,7 @@ const nishikiUserPool = (scope: Stack, stage: Stage): UserPool => {
 			callbackUrls: [
 				`https://${ssmParameters.cognitoDomainPrefix}.auth.${scope.region}.amazoncognito.com`,
 				"http://localhost:3000/login",
+				"https://nishiki.tech/login",
 			],
 		},
 	});


### PR DESCRIPTION
## Overviews of implementation
Allow access from localhost:3000. I ensured that the CORS error were resolved using front app and my personal AWS env.

## Review points
I began to think about whether I should define those addresses somewhere instead of hard coding. What do you think about it?

