### PR TITLE
fix: PUT invitationLink return json instead of string

### DIFF
--- a/backend/main/src/Shared/Adapters/HonoAdapter.ts
+++ b/backend/main/src/Shared/Adapters/HonoAdapter.ts
@@ -65,7 +65,7 @@ export const honoCreatedResponseAdapter = (
 	}
 	c.header("Content-Type", "application/json");
 	c.status(201);
-	return c.json(JSON.stringify(data));
+	return c.body(JSON.stringify(data));
 };
 
 /**


### PR DESCRIPTION
## Overviews of implementation
A string passed to json() method which is supposed to receive JSONObject arg, so I just changed the method.

## Review points

