### PR TITLE
fix: return json instead of string

### DIFF
--- a/backend/main/src/Shared/Adapters/HonoAdapter.ts
+++ b/backend/main/src/Shared/Adapters/HonoAdapter.ts
@@ -44,7 +44,7 @@ export const honoOkResponseAdapter = (
 	}
 	c.header("Content-Type", "application/json");
 	c.status(200);
-	return c.json(JSON.stringify(data));
+	return c.body(JSON.stringify(data));
 };
 
 /**


### PR DESCRIPTION
## Overviews of implementation
passed JSON string to body() method instead of json() method 
## Review points

