### PR TITLE
fix: not to return ControllerResultType data as response

### DIFF
--- a/backend/main/src/User/Router/UserRouter.ts
+++ b/backend/main/src/User/Router/UserRouter.ts
@@ -60,7 +60,7 @@ export const userRouter = (app: Hono) => {
 		const query = new FindUserQuery(nishikiDynamoDBClient);
 		const controller = new FindUserController(query);
 		const result = await controller.execute(id);
-		return honoOkResponseAdapter(c, result);
+		return honoResponseAdapter(c, result);
 	});
 
 	// update user name.


### PR DESCRIPTION
## Overviews of implementation
In the `UserRouter.ts` `GET /users/:id` route, `honoOkResponseAdapter` took a ControllerResultType Obj as an argument. It caused the wrong response format. So I passed it to `honoResponseAdapter` to return the content of the body if the result's status is ok.

## Review points

