### PR TITLE
Fix/321 members are not deleted even though the 204 response is returned

### DIFF
--- a/backend/main/src/Group/Repositories/GroupRepository.ts
+++ b/backend/main/src/Group/Repositories/GroupRepository.ts
@@ -86,17 +86,17 @@ export class GroupRepository implements IGroupRepository {
 		const deletingUsers = currentGroupUsers.filter(
 			(user) => !Group.userIds.some((userId) => userId.id === user.userId),
 		);
-		await Promise.all(
+
+		await Promise.all([
 			deletingUsers.map((user) =>
 				this.nishikiDbClient.deleteUserFromGroup(Group.id.id, user.userId),
 			),
-		);
-
-		await this.nishikiDbClient.saveGroup(Group.id.id, {
-			groupName: Group.name,
-			userIds: Group.userIds.map((userId) => userId.id),
-			containerIds: Group.containerIds.map((containerId) => containerId.id),
-		});
+			this.nishikiDbClient.saveGroup(Group.id.id, {
+				groupName: Group.name,
+				userIds: Group.userIds.map((userId) => userId.id),
+				containerIds: Group.containerIds.map((containerId) => containerId.id),
+			}),
+		]);
 	}
 
 	/**

--- a/backend/main/src/Group/Repositories/GroupRepository.ts
+++ b/backend/main/src/Group/Repositories/GroupRepository.ts
@@ -79,6 +79,19 @@ export class GroupRepository implements IGroupRepository {
 	 * @param Group
 	 */
 	async update(Group: Group): Promise<undefined> {
+		// delete users who are not in the updated group
+		const currentGroupUsers = await this.nishikiDbClient.listOfUsersInGroup(
+			Group.id.id,
+		);
+		const deletingUsers = currentGroupUsers.filter(
+			(user) => !Group.userIds.some((userId) => userId.id === user.userId),
+		);
+		await Promise.all(
+			deletingUsers.map((user) =>
+				this.nishikiDbClient.deleteUserFromGroup(Group.id.id, user.userId),
+			),
+		);
+
 		await this.nishikiDbClient.saveGroup(Group.id.id, {
 			groupName: Group.name,
 			userIds: Group.userIds.map((userId) => userId.id),

--- a/backend/main/src/Shared/Adapters/DB/NishikiTableClient.ts
+++ b/backend/main/src/Shared/Adapters/DB/NishikiTableClient.ts
@@ -378,6 +378,25 @@ export class NishikiDynamoDBClient {
 	}
 
 	/**
+	 * Delete a user from the group.
+	 * This function deletes the relation between the user and the group.
+	 * @param groupId
+	 * @param userId
+	 */
+	async deleteUserFromGroup(groupId: string, userId: string) {
+		const deleteUserFromGroupInput: DeleteItemInput = {
+			TableName: this.tableName,
+			Key: marshall({
+				PK: userId,
+				SK: `Group#${groupId}`,
+			}),
+		};
+
+		const command = new DeleteItemCommand(deleteUserFromGroupInput);
+		await this.dynamoClient.send(command);
+	}
+
+	/**
 	 * Add a link and hash data to the Table.
 	 * This function takes the link expiry Datetime as a parameter.
 	 * @param groupId - UUID of the group ID

--- a/backend/main/src/Shared/Adapters/DB/NishikiTableClient.ts
+++ b/backend/main/src/Shared/Adapters/DB/NishikiTableClient.ts
@@ -397,6 +397,22 @@ export class NishikiDynamoDBClient {
 	}
 
 	/**
+	 * Delete a container from the group.
+	 * This function deletes the relation between the container and the group.
+	 * @param groupId
+	 * @param containerId
+	 */
+	async deleteContainerFromGroup(groupId: string, containerId: string) {
+		const deleteContainerFromGroupInput: DeleteItemInput = {
+			TableName: this.tableName,
+			Key: marshall({
+				PK: groupId,
+				SK: `Container#${containerId}`,
+			}),
+		};
+	}
+
+	/**
 	 * Add a link and hash data to the Table.
 	 * This function takes the link expiry Datetime as a parameter.
 	 * @param groupId - UUID of the group ID

--- a/backend/main/src/Shared/Adapters/DB/NishikiTableClient.ts
+++ b/backend/main/src/Shared/Adapters/DB/NishikiTableClient.ts
@@ -410,6 +410,9 @@ export class NishikiDynamoDBClient {
 				SK: `Container#${containerId}`,
 			}),
 		};
+
+		const command = new DeleteItemCommand(deleteContainerFromGroupInput);
+		await this.dynamoClient.send(command);
 	}
 
 	/**

--- a/backend/main/test/Shared/Adapters/NishikiTableClient.test.ts
+++ b/backend/main/test/Shared/Adapters/NishikiTableClient.test.ts
@@ -272,10 +272,9 @@ describe.sequential("DynamoDB test client", () => {
 			const containerId = groupData.groupData[0].containerIds![0];
 
 			await nishikiClient.deleteContainerFromGroup(groupId, containerId);
+			const result = await nishikiClient.listOfContainers(groupId);
 
-			const result = await nishikiClient.getGroup({ containerId });
-
-			expect(result).toBeFalsy();
+			expect(result).not.toContain(containerId);
 		});
 	});
 

--- a/backend/main/test/Shared/Adapters/NishikiTableClient.test.ts
+++ b/backend/main/test/Shared/Adapters/NishikiTableClient.test.ts
@@ -252,6 +252,20 @@ describe.sequential("DynamoDB test client", () => {
 				expect(result).toEqual([]);
 			});
 		});
+
+		it("delete a user from a group", async () => {
+			const groupId = groupData.groupData[0].groupId;
+			const userId = groupData.groupData[0].users![0];
+
+			await nishikiClient.deleteUserFromGroup(groupId, userId);
+
+			const result = await nishikiClient.getUser({
+				userId,
+				groupId,
+			});
+
+			expect(result).toBeFalsy();
+		});
 	});
 
 	describe.sequential("join link expiry datetime", () => {

--- a/backend/main/test/Shared/Adapters/NishikiTableClient.test.ts
+++ b/backend/main/test/Shared/Adapters/NishikiTableClient.test.ts
@@ -266,6 +266,17 @@ describe.sequential("DynamoDB test client", () => {
 
 			expect(result).toBeFalsy();
 		});
+
+		it("delete a container from a group", async () => {
+			const groupId = groupData.groupData[0].groupId;
+			const containerId = groupData.groupData[0].containerIds![0];
+
+			await nishikiClient.deleteContainerFromGroup(groupId, containerId);
+
+			const result = await nishikiClient.getGroup({ containerId });
+
+			expect(result).toBeFalsy();
+		});
 	});
 
 	describe.sequential("join link expiry datetime", () => {


### PR DESCRIPTION
## Overviews of implementation
Fix the update method of GroupRepository so that it can delete users who don't exist in a udpated group.

## Review points
In the future, when we develop the new feature to a container to another group, it need to be modified. But for now, I leave it.